### PR TITLE
Fix inline code examples in ASE section of documentation

### DIFF
--- a/source/tutorials/ase.rst
+++ b/source/tutorials/ase.rst
@@ -22,7 +22,8 @@ The `nanover-ase` module provides the
 attach interactive molecular dynamics functionality and frame serving to the dynamics. 
 An example is given below, assuming an ASE Atoms object has been set up, named `atoms`:
 
-.. code python
+.. code-block:: python
+
     from ase import units
     from ase.md import Langevin
     from nanover.ase.imd_server import ASEImdServer
@@ -43,7 +44,8 @@ contains several Jupyter notebooks that explore how NanoVer can be used with Ope
 * `openmm_nanotube`: A notebook that runs a simulation of a carbon nanotube, then applies interactive forces to it from the notebook.
 * `nanover_nglview`: A notebook that assumes a server is already running, and visualises it with `NGLView <https://github.com/arose/nglview>`_. To run this notebook, ensure NGLView is installed with:
 
-.. code
+.. code-block:: python
+
     conda install nglview -c conda-forge
     # might need: jupyter-nbextension enable nglview --py --sys-prefix
 

--- a/source/tutorials/ase.rst
+++ b/source/tutorials/ase.rst
@@ -44,7 +44,7 @@ contains several Jupyter notebooks that explore how NanoVer can be used with Ope
 * `openmm_nanotube`: A notebook that runs a simulation of a carbon nanotube, then applies interactive forces to it from the notebook.
 * `nanover_nglview`: A notebook that assumes a server is already running, and visualises it with `NGLView <https://github.com/arose/nglview>`_. To run this notebook, ensure NGLView is installed with:
 
-.. code-block:: python
+.. code-block:: bash
 
     conda install nglview -c conda-forge
     # might need: jupyter-nbextension enable nglview --py --sys-prefix


### PR DESCRIPTION
Previously none of the code examples were showing on the ASE section of the documentation page. This PR should make the following code examples visible:
- The ASE with iMD example (block of python code)
- The conda installation of nglview example (block of bash code with comments)
The edits made include explicit definition of the programming language for each of the blocks of code, although this may not be necessary. Comments and suggested changes are welcome!