### PR TITLE
Clarify installation instructions for Jupyter and NGLView for tutorials

### DIFF
--- a/source/tutorials/tutorials.rst
+++ b/source/tutorials/tutorials.rst
@@ -11,7 +11,9 @@ The tutorials use `Jupyter notebooks <https://jupyter.org>`_, `NGLView <https://
 
 .. code-block:: bash
 
-   conda activate <nanover_conda_environment_name>
+   # Assuming NanoVer is installed in a conda environment named "nanover",
+   # change the name otherwise.
+   conda activate nanover
    conda install jupyter
    conda install nglview
    # On Windows only:

--- a/source/tutorials/tutorials.rst
+++ b/source/tutorials/tutorials.rst
@@ -7,6 +7,18 @@ This section provides tutorials on getting started with NanoVer.
 We assume familiarity with setting up simulations in whichever 
 framework you're running with NanoVer.
 
+The tutorials use `Jupyter notebooks <https://jupyter.org>`_, `NGLView <https://github.com/nglviewer/nglview>`_ for visualising trajectories, and while not strictly necessary, assumes you have the `NanoVer IMD VR <https://gitlab.com/intangiblerealities/nanover-applications/nanover-imd>`_ application installed. These can all be installed with conda:
+
+.. code-block:: bash
+
+   conda activate <nanover_conda_environment_name>
+   conda install jupyter
+   conda install nglview
+   # On Windows only:
+   conda install -c irl nanover-imd
+
+Please note that in order to use NGLView we recommend installing Jupyter notebooks using the conda command shown above: the use of JupyterLab is not advised due to `difficulties building and debugging <https://github.com/nglviewer/nglview/issues/845>`_ NGLView with JupyterLab.
+
 .. toctree::
    :maxdepth: 1
    :caption: Contents:

--- a/source/tutorials/tutorials.rst
+++ b/source/tutorials/tutorials.rst
@@ -17,7 +17,7 @@ The tutorials use `Jupyter notebooks <https://jupyter.org>`_, `NGLView <https://
    # On Windows only:
    conda install -c irl nanover-imd
 
-Please note that in order to use NGLView we recommend installing Jupyter notebooks using the conda command shown above: the use of JupyterLab is not advised due to `difficulties building and debugging <https://github.com/nglviewer/nglview/issues/845>`_ NGLView with JupyterLab.
+If you wish to access the Jupyter notebooks via `JupyterLab <https://jupyter.org>`_, installing JupyterLab **before** NGLView should install the correct dependencies for NGLView automatically (i.e. replacing ``conda install jupyter`` with ``conda install jupyterlab`` in the installation instructions above). If JupyterLab is installed outside of your conda environment, you will need to install `ipywidgets <https://ipywidgets.readthedocs.io/en/stable/>`_ in your NanoVer conda environment following  `these instructions <https://ipywidgets.readthedocs.io/en/latest/user_install.html#installing-in-jupyterlab-3-x>`_. 
 
 .. toctree::
    :maxdepth: 1

--- a/source/tutorials/tutorials.rst
+++ b/source/tutorials/tutorials.rst
@@ -7,7 +7,7 @@ This section provides tutorials on getting started with NanoVer.
 We assume familiarity with setting up simulations in whichever 
 framework you're running with NanoVer.
 
-The tutorials use `Jupyter notebooks <https://jupyter.org>`_, `NGLView <https://github.com/nglviewer/nglview>`_ for visualising trajectories, and while not strictly necessary, assumes you have the `NanoVer IMD VR <https://gitlab.com/intangiblerealities/nanover-applications/nanover-imd>`_ application installed. These can all be installed with conda:
+The tutorials use `Jupyter notebooks <https://jupyter.org>`_, `NGLView <https://github.com/nglviewer/nglview>`_ for visualising trajectories, and while not strictly necessary, assumes you have the `NanoVer IMD <https://github.com/irl2/nanover-imd>`_ application installed (i.e. the VR client). These can all be installed with conda:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This PR adds information concerning the packages required to use the Jupyter notebooks, specifically Jupyter notebooks and NGLView, to the landing page for the tutorials on the NanoVer documentation. It also adds information concerning how to use JupyterLab to view the Jupyter notebooks, and provides links to the relevant information for installing the necessary dependencies to interface JupyterLab with NGLView.
