### PR TITLE
Move citations from homepage to separate page

### DIFF
--- a/source/citations.rst
+++ b/source/citations.rst
@@ -1,0 +1,24 @@
+ .. _citations:
+
+How to cite NanoVer
+===================
+
+NanoVer is forked from Narupa. If you find it useful, please cite the following
+`paper <https://doi.org/10.1063/1.5092590>`_:
+
+APA
+###################
+
+Jamieson-Binnie, A. D., O’Connor, M. B., Barnoud, J., Wonnacott, M. D.,
+Bennie, S. J., & Glowacki, D. R. (2020, August 17). Narupa iMD: A VR-Enabled
+Multiplayer Framework for Streaming Interactive Molecular Simulations. ACM
+SIGGRAPH 2020 Immersive Pavilion. SIGGRAPH ’20: Special Interest Group on
+Computer Graphics and Interactive Techniques Conference.
+https://doi.org/10.1145/3388536.3407891
+
+.bib
+###################
+
+.. literalinclude:: narupa.bib
+
+

--- a/source/index.rst
+++ b/source/index.rst
@@ -61,6 +61,7 @@ Bib file:
    tutorials/tutorials.rst
    concepts/concepts.rst
    python/modules.rst
+   citations.rst
 
 
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -36,23 +36,6 @@ and our VR applications such as `iMD-VR <https://github.com/IRL2/nanover-imd>`_.
 * :ref:`Read tutorials <Tutorials>`
 * `Get the source code for the server <https://github.com/IRL2/nanover-protocol>`_
 
-Citation
-###################
-
-NanoVer is forked from Narupa. If you find it useful, please cite the following
-`paper <https://doi.org/10.1063/1.5092590>`_:
-
-Jamieson-Binnie, A. D., O’Connor, M. B., Barnoud, J., Wonnacott, M. D.,
-Bennie, S. J., & Glowacki, D. R. (2020, August 17). Narupa iMD: A VR-Enabled
-Multiplayer Framework for Streaming Interactive Molecular Simulations. ACM
-SIGGRAPH 2020 Immersive Pavilion. SIGGRAPH ’20: Special Interest Group on
-Computer Graphics and Interactive Techniques Conference.
-https://doi.org/10.1145/3388536.3407891
-
-Bib file:
-
-.. literalinclude:: narupa.bib
-
 .. toctree::
    :maxdepth: 2
    :caption: Contents:


### PR DESCRIPTION
This PR aims to declutter the homepage by removing the Citation heading (and its contents) from the homepage and moving it to a separate page that appears in the contents sidebar.

One note on this: when we were initially testing this change, the contents sidebar was not updating correctly, and it was necessary to run `make clean` before building the html in order for the heading of the new page to show up in the contents sidebar on all pages.

We plan to include a link to this page within the text on the homepage (e.g. To cite Nanover, see this page), but this may be better achieved in a separate PR once the rest of the text on the homepage has been settled on.