### PR TITLE
Add instructions on how to build docstrings to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Clone the repo, open a terminal, and install the dependencies:
 python -m pip install -r requirements.txt
 ```
 
+(OPTIONAL) In order to also build the docstring documentation, you also need to 
+install `nanover` and `nanover-lammps`:
+
+```
+conda install -c irl -c omnia -c conda-forge nanover-server
+conda install -c irl -c conda-forge nanover-lammps
+```
+
 Make sure the submodules are initialised: 
 
 ```


### PR DESCRIPTION
Perhaps obvious, but without installing NanoVer the docstrings don't build in the documentation, and all that one can see is the module/submodule etc. headings without the docstrings. This PR adds instructions to the README.md for how to install NanoVer and the NanoVer LAMMPS packages to make it clear to people like @hjstroud, and should fix Issue #22 