### PR TITLE
Change automatically generated `nanover` page to `Modules` page

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -87,6 +87,7 @@ def run_apidoc(_):
         "--implicit-namespaces",
         "--force",
         "--separate",
+        "--no-toc",
         "--module-first",
         "-o", "./source/python",
         "./temp/python-source/nanover"

--- a/source/index.rst
+++ b/source/index.rst
@@ -28,7 +28,7 @@ As a client-server application, NanoVer consists of:
    installation.rst
    tutorials/tutorials.rst
    concepts/concepts.rst
-   python/modules.rst
+   modules.rst
    citations.rst
 
 ----


### PR DESCRIPTION
This PR introduces a new file to enable control over the way of we include the docstrings documentation, as the previous way automatically generated the name of this page. With the present method, we are able to modify the docstrings documentation title page, to change the title and include information relevant to these docs on this page.

This is just an idea for how we can restructure this page, suggestions welcome!