### PR TITLE
Update reference to Modules in the Tutorials page

### DIFF
--- a/source/tutorials/tutorials.rst
+++ b/source/tutorials/tutorials.rst
@@ -34,4 +34,4 @@ If you wish to access the Jupyter notebooks via `JupyterLab <https://jupyter.org
 Further reading
 ---------------
 
-For more details, look at the documentation for the individual :mod:`modules <nanover>`.
+For more details, look at the documentation for the individual :mod:`modules <modules>`.


### PR DESCRIPTION
Since the change to the Modules page (#42), the reference in the Tutorials page needs to be updated.